### PR TITLE
Fix moveit_core unit tests

### DIFF
--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
     set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/../planning_scene;${CMAKE_CURRENT_BINARY_DIR}/../distance_field;${CMAKE_CURRENT_BINARY_DIR}/../collision_detection;${CMAKE_CURRENT_BINARY_DIR}/../robot_state;${CMAKE_CURRENT_BINARY_DIR}/../robot_model;${CMAKE_CURRENT_BINARY_DIR}/../utils")
   endif()
 
-  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp TIMEOUT 350)
+  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp TIMEOUT 500)
   target_link_libraries(test_collision_distance_field
     ${MOVEIT_LIB_NAME}
     moveit_collision_detection

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
     set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/../planning_scene;${CMAKE_CURRENT_BINARY_DIR}/../distance_field;${CMAKE_CURRENT_BINARY_DIR}/../collision_detection;${CMAKE_CURRENT_BINARY_DIR}/../robot_state;${CMAKE_CURRENT_BINARY_DIR}/../robot_model;${CMAKE_CURRENT_BINARY_DIR}/../utils")
   endif()
 
-  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp TIMEOUT 500)
+  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp TIMEOUT 1500)
   target_link_libraries(test_collision_distance_field
     ${MOVEIT_LIB_NAME}
     moveit_collision_detection

--- a/moveit_core/collision_distance_field/CMakeLists.txt
+++ b/moveit_core/collision_distance_field/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
     set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_BINARY_DIR}/../planning_scene;${CMAKE_CURRENT_BINARY_DIR}/../distance_field;${CMAKE_CURRENT_BINARY_DIR}/../collision_detection;${CMAKE_CURRENT_BINARY_DIR}/../robot_state;${CMAKE_CURRENT_BINARY_DIR}/../robot_model;${CMAKE_CURRENT_BINARY_DIR}/../utils")
   endif()
 
-  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp)
+  ament_add_gtest(test_collision_distance_field test/test_collision_distance_field.cpp TIMEOUT 350)
   target_link_libraries(test_collision_distance_field
     ${MOVEIT_LIB_NAME}
     moveit_collision_detection

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTING)
     ${MOVEIT_LIB_NAME}
   )
 
-  ament_add_gtest(test_distance_field test/test_distance_field.cpp TIMEOUT 500)
+  ament_add_gtest(test_distance_field test/test_distance_field.cpp TIMEOUT 1500)
 
   target_link_libraries(test_distance_field
     ${MOVEIT_LIB_NAME}

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTING)
     ${MOVEIT_LIB_NAME}
   )
 
-  ament_add_gtest(test_distance_field test/test_distance_field.cpp)
+  ament_add_gtest(test_distance_field test/test_distance_field.cpp TIMEOUT 350)
 
   target_link_libraries(test_distance_field
     ${MOVEIT_LIB_NAME}

--- a/moveit_core/distance_field/CMakeLists.txt
+++ b/moveit_core/distance_field/CMakeLists.txt
@@ -31,7 +31,7 @@ if(BUILD_TESTING)
     ${MOVEIT_LIB_NAME}
   )
 
-  ament_add_gtest(test_distance_field test/test_distance_field.cpp TIMEOUT 350)
+  ament_add_gtest(test_distance_field test/test_distance_field.cpp TIMEOUT 500)
 
   target_link_libraries(test_distance_field
     ${MOVEIT_LIB_NAME}

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -73,7 +73,7 @@ if(BUILD_TESTING)
   )
 
   # As an executable, this benchmark is not run as a test by default
-  ament_add_gtest(test_robot_state_benchmark test/robot_state_benchmark.cpp)
+  ament_add_gtest(test_robot_state_benchmark test/robot_state_benchmark.cpp TIMEOUT 350)
     target_include_directories(test_robot_state_benchmark PUBLIC
     ${tf2_geometry_msgs_INCLUDE_DIRS}
     ${urdf_INCLUDE_DIRS}

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -73,7 +73,7 @@ if(BUILD_TESTING)
   )
 
   # As an executable, this benchmark is not run as a test by default
-  ament_add_gtest(test_robot_state_benchmark test/robot_state_benchmark.cpp TIMEOUT 350)
+  ament_add_gtest(test_robot_state_benchmark test/robot_state_benchmark.cpp TIMEOUT 1500)
     target_include_directories(test_robot_state_benchmark PUBLIC
     ${tf2_geometry_msgs_INCLUDE_DIRS}
     ${urdf_INCLUDE_DIRS}


### PR DESCRIPTION
### Description

The reason why the unit tests are failing is that when we add [ament_add_gtest](https://github.com/ament/ament_cmake/blob/master/ament_cmake_gtest/cmake/ament_add_gtest.cmake) the [timeout default](https://github.com/ament/ament_cmake/blob/master/ament_cmake_test/cmake/ament_add_test.cmake#L30) is 60s which is lower than what running the unit tests takes, for the tests that take more than 60s I set the timeout to the ctest default value which is 1500s

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
