### PR TITLE
Add locale install in BEFORE_SCRIPT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
       - 130s@2000.jukuin.keio.ac.jp
 env:
   global:
+    - BEFORE_SCRIPT="sudo apt-get -qq install -y locales; sudo locale-gen en_US.UTF-8"
     - MOVEIT_CI_TRAVIS_TIMEOUT=85  # Travis grants us 90 min, but we add a safety margin of 5 min
     - ROS_DISTRO=dashing
     - ROS_REPO=ros


### PR DESCRIPTION
Seems `en_US.UTF-8` is also missing in the moveit2 docker image, as the warning shown in the [CI report](https://travis-ci.org/ros-planning/moveit2/jobs/612461783#L638) of moveit2. In order to suppress the locale missing warning, it is necessary to add locale installation commands `- BEFORE_SCRIPT="sudo apt-get -qq install -y locales; sudo locale-gen en_US.UTF-8"` when using moveit_ci.
