### PR TITLE
Fix moveit_core unit tests

### DIFF
--- a/moveit_core/kinematic_constraints/test/test_constraints.cpp
+++ b/moveit_core/kinematic_constraints/test/test_constraints.cpp
@@ -668,7 +668,10 @@ TEST_F(LoadPlanningModelsPr2, VisibilityConstraintsSimple)
 
   vcm.sensor_pose.header.frame_id = "base_footprint";
   vcm.sensor_pose.pose.position.z = -1.0;
+  vcm.sensor_pose.pose.orientation.x = 0.0;
   vcm.sensor_pose.pose.orientation.y = 1.0;
+  vcm.sensor_pose.pose.orientation.z = 0.0;
+  vcm.sensor_pose.pose.orientation.w = 0.0;
 
   vcm.target_pose.header.frame_id = "base_footprint";
   vcm.target_pose.pose.position.z = -2.0;


### PR DESCRIPTION
### Description

The reason for Travis failing is in Eloquent the default Quaternion message have been changed [see](https://index.ros.org/doc/ros2/Releases/Release-Eloquent-Elusor/#geometry-msgs) 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
